### PR TITLE
Fix issue of copying/pasting images from PowerPoint

### DIFF
--- a/app/javascript/widgets/graphicsWidget.js
+++ b/app/javascript/widgets/graphicsWidget.js
@@ -559,7 +559,7 @@ wpd.graphicsWidget = (function() {
             let items = ev.clipboardData.items;
             if (items !== undefined) {
                 for (var i = 0; i < items.length; i++) {
-                    if (items[i].type.indexOf("image") !== -1) {
+                    if (items[i].kind === "file" && items[i].type.indexOf("image") !== -1) {
                         wpd.busyNote.show();
                         var imageFile = items[i].getAsFile();
                         wpd.imageManager.initializeFileManager([imageFile]);


### PR DESCRIPTION
This could fix #301 .

I encountered the same problem as #301 that the page got stuck with "Processing...".

Through console debugging, I found that when copying/pasting a figure from PowerPoint, there may be two items in `ev.clipboardData.items`, namely

```plain
DataTransferItemList {0: DataTransferItem, 1: DataTransferItem, length: 2}
> 0: DataTransferItem {kind: 'string', type: 'image/svg+xml'}
> 1: DataTransferItem {kind: 'file', type: 'image/png'}
  length: 2
> [[Prototype]]: DataTransferItemList
```

Both items have `type` containing substring `"image"`, but only the item with `kind === "file"` is valid for the method `.getAsFile()`, so an additional judgement `items[i].kind === "file"` will help exclude invalid items.

The issue seems related to the specific versions and settings of PowerPoint, as the issue exists with my PowerPoint (MS Office 2016, Windows 10) but not with some other versions (for example, MS Office 2019, Windows 10).
